### PR TITLE
Improve installation command formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ It's object-oriented and makes a quick, yet concise approach to remove spam easy
 ## Installation
 You can install spamfilter by cloning the GitHub repository, downloading it from the GitHub page or using pip:
 
-`pip install spamfilter`
+```bash
+$ pip install spamfilter
+```
 
 ## Usage
 Define a machine using several spam filters stacked onto each other.


### PR DESCRIPTION
This pull request wraps the pip installation command in a code block using triple backticks, so the rendering of it on the README is improved ever so slightly.